### PR TITLE
Increase log size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ For inspiration, see https://github.com/jakevdp/altair-transform
 ## Getting started
 
 ```bash
-pip install ibis-vega-transform
-jupyter labextension install \
-    ibis-vega-transform \
-    "tornado<6"
+pip install ibis-vega-transform "tornado<6"
+jupyter labextension install ibis-vega-transform
 ```
 
 Then in a notebook, import the Python package and pass in an ibis expression

--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@ For inspiration, see https://github.com/jakevdp/altair-transform
 pip install ibis-vega-transform
 jupyter labextension install \
     ibis-vega-transform \
-    "tornado<6" \
-    jupyterlab-server-proxy-saulshanabrook # optional, if you want to see icon in JL to launch tracing GUI
-
-# Optionally install `jaeger-all-in-one` binary and add to path to see tracing
-# https://www.jaegertracing.io/download/
+    "tornado<6"
 ```
 
 Then in a notebook, import the Python package and pass in an ibis expression
@@ -44,6 +40,9 @@ alt.Chart(table).mark_bar().encode(
 Check out the notebooks in the [`./examples/`](./examples/) directory to see
 some options using interactive charts and the OmniSci backend.
 
+
+### Dashboards
+
 You can also create dashboards with this with Phoila.
 
 ![](./docs/dashboard.png)
@@ -53,6 +52,23 @@ pip install git+https://github.com/Quansight/phoila.git@comm_open "notebook<6.0"
 phoila install ibis-vega-transform
 phoila "examples/Charting Example.ipynb"
 ```
+
+### Tracing
+
+If you want to see traces of the interactiosn for debugging and performance analysis,
+install tthe `jaeger-all-in-one` binary and the `jupyterlab-server-proxy-saulshanabrook`
+lab extension to see the Jaeger icon in the launcher.
+
+
+Then open up the Jaeger tracer before running the notebook, run some visualizations and look at the traces.
+
+You also will likely have to increase the max UDP packet size on your OS to [accomdate for the large logs](https://github.com/jaegertracing/jaeger-client-node/issues/124#issuecomment-324222456):
+
+```bash
+# Mac
+sudo sysctl net.inet.udp.maxdgram=200000
+```
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ If you want to see traces of the interactiosn for debugging and performance anal
 install tthe `jaeger-all-in-one` binary and the `jupyterlab-server-proxy-saulshanabrook`
 lab extension to see the Jaeger icon in the launcher.
 
-
-Then open up the Jaeger tracer before running the notebook, run some visualizations and look at the traces.
+TheJjaeger server won't actually be started until a HTTP request is sent to it,
+so before you run your visualization, click the "Jaeger" icon in the JupyterLab launcher or go to
+`/jaeger` to open the UI. Then run your visualization and you should see the traces appear in Jaeger.
 
 You also will likely have to increase the max UDP packet size on your OS to [accomdate for the large logs](https://github.com/jaegertracing/jaeger-client-node/issues/124#issuecomment-324222456):
 

--- a/ibis_vega_transform/tracer.py
+++ b/ibis_vega_transform/tracer.py
@@ -5,7 +5,12 @@ __all__ = ["tracer"]
 
 
 jaeger_config = jaeger_client.Config(
-    config={"sampler": {"type": "const", "param": 1}, "logging": True},
+    config={
+        "sampler": {"type": "const", "param": 1},
+        "logging": True,
+        # Increase max length of logs so we can save vega lite specs
+        "max_tag_value_length": 1000 * 100,
+    },
     service_name=os.environ.get("JAEGER_SERVICE_NAME", "kernel"),
     validate=True,
 )


### PR DESCRIPTION
Fixes https://github.com/Quansight/ibis-vega-transform/issues/25 by increasing max log size limit so we can see generated Vega and Vega Lite specs for debugging.