### PR TITLE
Fix bug in tracing logic so each transform has the same base trace

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -122,7 +122,7 @@ class QueryIbis extends dataflow.Transform implements vega.Transform {
 
     // set span inside comm to be this comm message instead of root span
     if (tracing) {
-      parameters.span = await client.injectSpan(commSpan!);
+      parameters = { ...parameters, span: await client.injectSpan(commSpan!) };
     }
 
     await comm.open(parameters).done;


### PR DESCRIPTION
Previously, later traces were being save with the parent ID of earlier traces leading to inaccurate reporting. This was because parameters object was mutated instead of copying it first.

Before:

<img width="1920" alt="Screen Shot 2019-11-12 at 3 01 50 PM" src="https://user-images.githubusercontent.com/1186124/68708272-5daff280-0561-11ea-8e6e-bedcdc0bdc5e.png">
After:
<img width="1920" alt="Screen Shot 2019-11-12 at 3 17 03 PM" src="https://user-images.githubusercontent.com/1186124/68708278-61437980-0561-11ea-96ca-5fca7a9cdce2.png">
